### PR TITLE
CxOne branch is case sensitive. Removed tolower when comparing

### DIFF
--- a/Checkmarx.API.AST/ASTClient.cs
+++ b/Checkmarx.API.AST/ASTClient.cs
@@ -798,7 +798,7 @@ namespace Checkmarx.API.AST
                     scans = scans.Where(x => x.Status == Status.Completed || x.Status == Status.Partial);
 
                 if (!string.IsNullOrEmpty(branch))
-                    scans = scans.Where(x => x.Branch.ToLower() == branch.ToLower());
+                    scans = scans.Where(x => x.Branch == branch);
 
                 if (maxScanDate != null)
                     scans = scans.Where(x => x.CreatedAt <= maxScanDate);


### PR DESCRIPTION
It is possible in CxOne to create two branches with the same name: "Main" and "main" are two different branches. Cannot use ToLower() when comparing.