### PR TITLE
Small fix on the scan engine status validation

### DIFF
--- a/Checkmarx.API.AST/ASTClient.cs
+++ b/Checkmarx.API.AST/ASTClient.cs
@@ -820,7 +820,7 @@ namespace Checkmarx.API.AST
                     if (!string.IsNullOrEmpty(engine))
                     {
                         if (scan.Engines != null && scan.Engines.Any(x => x == engine &&
-                                (scan.StatusDetails?.SingleOrDefault(x => x.Name == engine)?.Status == CompletedStage)))
+                            (scan.Status == Status.Completed || scan.StatusDetails?.SingleOrDefault(x => x.Name == engine)?.Status == CompletedStage)))
                         {
                             list.Add(scan);
                         }


### PR DESCRIPTION
In older versions status details can indeed be null. With this change a scan with the specified engine and global scan status "Completed" will be accepted as valid. If the status is not completed, it will then check the status details. If the status details is not Completed or there is none, it will discard the scan.