### PR TITLE
Removed the clone for Upload request

### DIFF
--- a/Checkmarx.API.AST/Services/Uploads.cs
+++ b/Checkmarx.API.AST/Services/Uploads.cs
@@ -205,7 +205,7 @@ namespace Checkmarx.API.AST.Services.Uploads
 
                     PrepareRequest(client_, request_, url_);
 
-                    var response_ = await _retryPolicy.ExecuteAsync(() => client_.SendAsync(CloneHttpRequestMessage(request_), System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken)).ConfigureAwait(false);
+                    var response_ = await _retryPolicy.ExecuteAsync(() => client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken)).ConfigureAwait(false);
                     var disposeResponse_ = true;
                     try
                     {


### PR DESCRIPTION
Removed the clone for the Upload request, causing error - Unable to write content to request stream; content would exceed Content-Length