### PR TITLE
Removed GetTenantPresets

### DIFF
--- a/Checkmarx.API.AST.Tests/ProjectTests.cs
+++ b/Checkmarx.API.AST.Tests/ProjectTests.cs
@@ -58,7 +58,10 @@ namespace Checkmarx.API.AST.Tests
         [TestMethod]
         public void GetPresetsTest()
         {
-            var presets = astclient.GetTenantPresets();
+            var presets = astclient.GetAllPresets();
+
+            foreach (var preset in presets)
+                Trace.WriteLine(preset.Name);
         }
 
         [TestMethod]

--- a/Checkmarx.API.AST/ASTClient.cs
+++ b/Checkmarx.API.AST/ASTClient.cs
@@ -1748,20 +1748,6 @@ namespace Checkmarx.API.AST
 
         #region Queries and Presets
 
-        public List<string> GetTenantPresets()
-        {
-            var configuration = GetTenantConfigurations();
-            if (configuration.ContainsKey(SettingsProjectPreset))
-            {
-                var config = configuration[SettingsProjectPreset];
-
-                if (config != null && !string.IsNullOrWhiteSpace(config.ValueTypeParams))
-                    return config.ValueTypeParams.Split(',').Select(x => x.Trim()).ToList();
-            }
-
-            return null;
-        }
-
         public IEnumerable<PresetDetails> GetAllPresetsDetails()
         {
             foreach (var preset in GetAllPresets())


### PR DESCRIPTION
No longer returning the preset list from the tenant configuration. GetAllPresets() or GetAllPresetsDetails() should be used instead.