### PR TITLE
Fix MarkSASTResult propagating custom states via raw string

### DIFF
--- a/Checkmarx.API.AST/ASTClient.cs
+++ b/Checkmarx.API.AST/ASTClient.cs
@@ -2091,7 +2091,11 @@ namespace Checkmarx.API.AST
 
                 if (updateState)
                 {
-                    newBody.State = predicate.State;
+                    var predicateState = SASTStates.SingleOrDefault(x => x.Name.Equals(predicate.State, StringComparison.InvariantCultureIgnoreCase));
+                    if (predicateState?.State.HasValue == true)
+                        newBody.State = predicateState.State.Value.ToString();
+                    else if (predicateState != null)
+                        newBody.CustomStateId = predicateState.Id;
                 }
                 else
                 {


### PR DESCRIPTION
When updateState=true, resolve the predicate's state through the SASTStates lookup instead of copying the raw name string. Standard states set newBody.State; custom states set newBody.CustomStateId.
Sending both fields simultaneously will cause a 500 from the API.